### PR TITLE
Cache compressed samples

### DIFF
--- a/main.py
+++ b/main.py
@@ -444,6 +444,7 @@ def main():
     trainparser.add_argument("-t", "--threads", help="Max number of threads to use for decompression (torch may use more)", default=4, type=int)
     trainparser.add_argument("-ap", "--altpredictor", help="The file to load altpredictor module from")
     trainparser.add_argument("-tap", "--train-altpredictor", help="Train altpredictor module", action='store_true')
+    trainparser.add_argument("-mc", "--max-cache-size", help="Max number of train data files to store in RAM", type=int, default=1000)
     trainparser.add_argument("-md", "--max-decomp-batches",
                              help="Max number batches to decompress and store in memory at once", default=4, type=int)
     trainparser.add_argument("-b", "--batch-size", help="The batch size, default is 64", type=int, default=64)

--- a/train.py
+++ b/train.py
@@ -390,6 +390,7 @@ def train(config, output_model, input_model, epochs, **kwargs):
         dataloader = loader.PregenLoader(DEVICE,
                                          kwargs.get("datadir"),
                                          threads=kwargs.get('threads'),
+                                         max_cache_size=kwargs.get('max_cache_size', 1000),
                                          max_decomped_batches=kwargs.get('max_decomp_batches'))
     else:
         logger.info(f"Using on-the-fly training data from sim loader")


### PR DESCRIPTION
Adds a simple caching mechanism for PregenLoader that stores raw file contents (without decompressing) in RAM, instead of loading them from disk every time. We still decompress in parallel, and don't cache the decompressed data. I think this will be helpful on systems with lots of RAM but not super fast IO (like kingspeak machines)
 Max cache size can be set from command line with the `--max-cache-size` option, which defaults to 1000, but could probably be pretty big (like 10,000+?) on kingspeak machines