### PR TITLE
Sw trim width

### DIFF
--- a/model.py
+++ b/model.py
@@ -126,7 +126,7 @@ class VarTransformerAltMask(nn.Module):
     def __init__(self, read_depth, feature_count, out_dim, nhead=6, d_hid=256, n_encoder_layers=2, p_dropout=0.1, device='cpu'):
         super().__init__()
         self.device=device
-        self.embed_dim = nhead * 30
+        self.embed_dim = nhead * 20
         self.conv_out_channels = 10
         self.fc1_hidden = 12
 

--- a/train.py
+++ b/train.py
@@ -203,7 +203,7 @@ def train_epochs(epochs,
 
     attention_heads = 8
     transformer_dim = 400
-    encoder_layers = 5
+    encoder_layers = 4
     model = VarTransformerAltMask(read_depth=max_read_depth, 
                                     feature_count=feats_per_read, 
                                     out_dim=4, 


### PR DESCRIPTION
Adds an option to have the SW loss compute over a set of bases in the middle of the sequence, for instance the middle 100 bases. This really improves performance, but is weird since the loss just totally ignores predicted bases outside of this region. It is off by default but can be set by providing the `trim_width` keyword argument to the SmithWatermanLoss 