### PR TITLE
set wandb.init dir to working dir

### DIFF
--- a/train.py
+++ b/train.py
@@ -345,6 +345,7 @@ def train_epochs(epochs,
                 config=wandb_config_params,
                 project='variant-transformer',
                 entity='arup-rnd',
+                dir=current_working_dir,
                 name=wandb_run_name,
                 notes=wandb_notes,
         )


### PR DESCRIPTION
found one small bug that puts the wandb logging dir in the wrong folder. This one line fix seems to get the wandb dir inside the run directory.